### PR TITLE
Tensorstore afdist

### DIFF
--- a/software/ts-afdist/CMakeLists.txt
+++ b/software/ts-afdist/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Almost all CMake files should start with this
+# You should always specify a range with the newest
+# and oldest tested versions of CMake. This will ensure
+# you pick up the best policies.
+cmake_minimum_required(VERSION 3.1...3.29)
+
+# This is your project statement. You should always list languages;
+# Listing the version is nice here since it sets lots of useful variables
+project(
+  ts_afdist
+  VERSION 1.0
+  LANGUAGES CXX)
+
+# If you set any CMAKE_ variables, that can go here.
+# (But usually don't do this, except maybe for C++ standard)
+
+# Find packages go here.
+
+# You should usually split this into folders, but this is a simple example
+
+# This is a "default" library, and will match the *** variable setting.
+# Other common choices are STATIC, SHARED, and MODULE
+# Including header files here helps IDEs but is not required.
+# Output libname matches target name, with the usual extensions on your system
+# add_library(MyLibExample simple_lib.cpp simple_lib.hpp)
+
+# Link each target with other targets or add options, etc.
+
+# Adding something we can run - Output name matches target name
+add_executable(ts_afdist ts_afdist.cpp)
+
+# # Make sure you link your targets with this command. It can also link libraries and
+# # even flags, so linking a target that does not exist will not give a configure-time error.
+# target_link_libraries(MyExample PRIVATE MyLibExample)

--- a/software/ts-afdist/CMakeLists.txt
+++ b/software/ts-afdist/CMakeLists.txt
@@ -11,6 +11,10 @@ project(
   VERSION 1.0
   LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 
 # Adding something we can run - Output name matches target name
 add_executable(ts_afdist ts_afdist.cpp)

--- a/software/ts-afdist/CMakeLists.txt
+++ b/software/ts-afdist/CMakeLists.txt
@@ -11,24 +11,26 @@ project(
   VERSION 1.0
   LANGUAGES CXX)
 
-# If you set any CMAKE_ variables, that can go here.
-# (But usually don't do this, except maybe for C++ standard)
-
-# Find packages go here.
-
-# You should usually split this into folders, but this is a simple example
-
-# This is a "default" library, and will match the *** variable setting.
-# Other common choices are STATIC, SHARED, and MODULE
-# Including header files here helps IDEs but is not required.
-# Output libname matches target name, with the usual extensions on your system
-# add_library(MyLibExample simple_lib.cpp simple_lib.hpp)
-
-# Link each target with other targets or add options, etc.
 
 # Adding something we can run - Output name matches target name
 add_executable(ts_afdist ts_afdist.cpp)
 
-# # Make sure you link your targets with this command. It can also link libraries and
-# # even flags, so linking a target that does not exist will not give a configure-time error.
-# target_link_libraries(MyExample PRIVATE MyLibExample)
+include(FetchContent)
+
+FetchContent_Declare(
+    tensorstore
+    URL "https://github.com/google/tensorstore/archive/refs/tags/v0.1.64.tar.gz"
+    URL_HASH SHA256=1dc632c6e9f83c033a2a16fe1a67ca38825902083ea0efe314769eee980c3126
+)
+
+# Additional FetchContent_Declare calls as needed...
+
+FetchContent_MakeAvailable(tensorstore)
+
+# Define a target that depends on TensorStore...
+
+target_link_libraries(
+    ts_afdist
+    PRIVATE
+    tensorstore::tensorstore tensorstore::all_drivers
+    )

--- a/software/ts-afdist/ts_afdist.cpp
+++ b/software/ts-afdist/ts_afdist.cpp
@@ -12,7 +12,7 @@
 using ::tensorstore::Index;
 using ::tensorstore::TensorStore;
 
-absl::Status Run(tensorstore::Spec input_spec) {
+absl::Status Run(tensorstore::Spec &input_spec) {
     TensorStore<int8_t, tensorstore::dynamic_rank, tensorstore::ReadWriteMode::dynamic> store;
     TENSORSTORE_ASSIGN_OR_RETURN(
         store,
@@ -24,61 +24,62 @@ absl::Status Run(tensorstore::Spec input_spec) {
     const Index sample_count = shape[1];
 
     tensorstore::ChunkLayout chunk_layout;
-    TENSORSTORE_ASSIGN_OR_RETURN(
-        chunk_layout, store.chunk_layout());
+    TENSORSTORE_ASSIGN_OR_RETURN(chunk_layout, store.chunk_layout());
 
     tensorstore::ChunkLayout::ReadChunkShape chunk_shape = chunk_layout.read_chunk_shape();
-    const Index variant_chunk_size = chunk_shape[0];
-    const Index sample_chunk_size = chunk_shape[1];
+    const Index variant_chunk_size = std::min(chunk_shape[0], variant_count);
+    const Index sample_chunk_size = std::min(chunk_shape[1], sample_count);
     std::vector<uint64_t> bin_counts(11);
+    std::vector<int8_t> data_vector(variant_chunk_size * sample_chunk_size * 2);
 
-    for (Index variant_chunk_start = 0; variant_chunk_start < variant_count; variant_chunk_start += variant_chunk_size) {
+    for (Index variant_chunk_start = 0; variant_chunk_start < variant_count;
+         variant_chunk_start += variant_chunk_size) {
+        const Index variant_chunk_end = std::min(variant_count, variant_chunk_start + variant_chunk_size);
+        std::vector<uint64_t> ref_counts(variant_chunk_end - variant_chunk_start);
+        std::vector<uint64_t> het_counts(variant_chunk_end - variant_chunk_start);
+        std::vector<uint64_t> hom_alt_counts(variant_chunk_end - variant_chunk_start);
+
         for (Index sample_chunk_start = 0; sample_chunk_start < sample_count; sample_chunk_start += sample_chunk_size) {
-            const Index variant_chunk_end = std::min(variant_count, variant_chunk_start + variant_chunk_size);
             const Index sample_chunk_end = std::min(sample_count, sample_chunk_start + sample_chunk_size);
-            tensorstore::SharedArray<int8_t, tensorstore::dynamic_rank, tensorstore::offset_origin> array;
 
-            TENSORSTORE_ASSIGN_OR_RETURN(array, tensorstore::Read(store | tensorstore::Dims(0, 1).HalfOpenInterval(
-                                                                              {variant_chunk_start, sample_chunk_start},
-                                                                              {variant_chunk_end, sample_chunk_end}))
-                                                    .result());
+            tensorstore::SharedArray<int8_t, 3L, tensorstore::ArrayOriginKind::zero> array =
+                tensorstore::UnownedToShared(tensorstore::Array(
+                    data_vector.data(), {variant_chunk_size, sample_chunk_size, 2}, tensorstore::c_order));
+            tensorstore::Read(
+                store | tensorstore::Dims(0, 1).HalfOpenInterval({variant_chunk_start, sample_chunk_start},
+                                                                 {variant_chunk_end, sample_chunk_end}),
+                array)
+                .Wait();
 
-            for (Index variant_index = variant_chunk_start; variant_index < variant_chunk_end; variant_index++) {
-                uint64_t hom_ref_count = 0;
-                uint64_t hom_alt_count = 0;
-                uint64_t het_count = 0;
-                uint64_t ref_count = 0;
+            for (Index variant_index = 0; variant_index < variant_chunk_end - variant_chunk_start; variant_index++) {
+                for (Index sample_index = 0; sample_index < sample_chunk_end - sample_chunk_start; sample_index++) {
+                    const Index call_index = 2 * (sample_chunk_size * variant_index + sample_index);
+                    const int8_t a = data_vector[call_index];
+                    const int8_t b = data_vector[call_index + 1];
 
-                for (Index sample_index = sample_chunk_start; sample_index < sample_chunk_end; sample_index++) {
-                    const int8_t a = array(variant_index, sample_index, 0);
-                    const int8_t b = array(variant_index, sample_index, 1);
-
-                    if (std::min(a, b) < 0) continue;
-
-                    if (a == b)
-                        if (a == 0)
-                            hom_ref_count += 1;
-                        else
-                            hom_alt_count += 1;
-                    else
-                        het_count += 1;
-
-                    if (a == 0) ref_count += 1;
-                    if (b == 0) ref_count += 1;
+                    ref_counts[variant_index] += (a == 0) + (b == 0);
+                    het_counts[variant_index] += a != b;
+                    hom_alt_counts[variant_index] += a == b && a > 0;
                 }
-
-                const uint64_t alt_count = 2 * sample_count - ref_count;
-                const double alt_freq = alt_count / (2.0 * sample_count);
-                const double het_ref_freq = 2 * alt_freq * (1 - alt_freq);
-                const double hom_alt_freq = alt_freq * alt_freq;
-                Index bin_index = 10 * het_ref_freq;
-
-                bin_counts[bin_index] += het_count;
-
-                bin_index = 10 * hom_alt_freq;
-
-                bin_counts[bin_index] += hom_alt_count;
             }
+        }
+
+        for (Index variant_index = 0; variant_index < variant_chunk_end - variant_chunk_start; variant_index++) {
+            const uint64_t ref_count = ref_counts[variant_index];
+            const uint64_t het_count = het_counts[variant_index];
+            const uint64_t hom_alt_count = hom_alt_counts[variant_index];
+
+            const uint64_t alt_count = 2 * sample_count - ref_count;
+            const double alt_freq = alt_count / (2.0 * sample_count);
+            const double het_ref_freq = 2 * alt_freq * (1 - alt_freq);
+            const double hom_alt_freq = alt_freq * alt_freq;
+            Index bin_index = 10 * het_ref_freq;
+
+            bin_counts[bin_index] += het_count;
+
+            bin_index = 10 * hom_alt_freq;
+
+            bin_counts[bin_index] += hom_alt_count;
         }
     }
 

--- a/software/ts-afdist/ts_afdist.cpp
+++ b/software/ts-afdist/ts_afdist.cpp
@@ -1,0 +1,7 @@
+
+#include <iostream>
+
+int main(int argc, char* argv[]) {
+    std::cout << "hello\n";
+    return 0;
+}

--- a/software/ts-afdist/ts_afdist.cpp
+++ b/software/ts-afdist/ts_afdist.cpp
@@ -23,53 +23,61 @@ absl::Status Run(tensorstore::Spec input_spec) {
     const Index variant_count = shape[0];
     const Index sample_count = shape[1];
 
-    // tensorstore::ChunkLayout chunk_layout;
-    // TENSORSTORE_ASSIGN_OR_RETURN(
-    //     chunk_layout, store.chunk_layout());
+    tensorstore::ChunkLayout chunk_layout;
+    TENSORSTORE_ASSIGN_OR_RETURN(
+        chunk_layout, store.chunk_layout());
 
-    // tensorstore::ChunkLayout::ReadChunkShape chunk_shape = chunk_layout.read_chunk_shape();
-    // const Index variant_chunk_size = chunk_shape[0];
-    // const Index sample_chunk_size = chunk_shape[1];
-
-    tensorstore::SharedArray<int8_t, tensorstore::dynamic_rank, tensorstore::offset_origin> array;
-
-    TENSORSTORE_ASSIGN_OR_RETURN(array, tensorstore::Read(store).result());
-
+    tensorstore::ChunkLayout::ReadChunkShape chunk_shape = chunk_layout.read_chunk_shape();
+    const Index variant_chunk_size = chunk_shape[0];
+    const Index sample_chunk_size = chunk_shape[1];
     std::vector<uint64_t> bin_counts(11);
 
-    for (Index variant_index = 0; variant_index < variant_count; variant_index++) {
-        uint64_t hom_ref_count = 0;
-        uint64_t hom_alt_count = 0;
-        uint64_t het_count = 0;
-        uint64_t ref_count = 0;
+    for (Index variant_chunk_start = 0; variant_chunk_start < variant_count; variant_chunk_start += variant_chunk_size) {
+        for (Index sample_chunk_start = 0; sample_chunk_start < sample_count; sample_chunk_start += sample_chunk_size) {
+            const Index variant_chunk_end = std::min(variant_count, variant_chunk_start + variant_chunk_size);
+            const Index sample_chunk_end = std::min(sample_count, sample_chunk_start + sample_chunk_size);
+            tensorstore::SharedArray<int8_t, tensorstore::dynamic_rank, tensorstore::offset_origin> array;
 
-        for (Index sample_index = 0; sample_index < sample_count; sample_index++) {
-            const int8_t a = array(variant_index, sample_index, 0);
-            const int8_t b = array(variant_index, sample_index, 1);
+            TENSORSTORE_ASSIGN_OR_RETURN(array, tensorstore::Read(store | tensorstore::Dims(0, 1).HalfOpenInterval(
+                                                                              {variant_chunk_start, sample_chunk_start},
+                                                                              {variant_chunk_end, sample_chunk_end}))
+                                                    .result());
 
-            if (a == b)
-                if (a == 0)
-                    hom_ref_count += 1;
-                else
-                    hom_alt_count += 1;
-            else
-                het_count += 1;
+            for (Index variant_index = variant_chunk_start; variant_index < variant_chunk_end; variant_index++) {
+                uint64_t hom_ref_count = 0;
+                uint64_t hom_alt_count = 0;
+                uint64_t het_count = 0;
+                uint64_t ref_count = 0;
 
-            if (a == 0) ref_count += 1;
-            if (b == 0) ref_count += 1;
+                for (Index sample_index = sample_chunk_start; sample_index < sample_chunk_end; sample_index++) {
+                    const int8_t a = array(variant_index, sample_index, 0);
+                    const int8_t b = array(variant_index, sample_index, 1);
+
+                    if (a == b)
+                        if (a == 0)
+                            hom_ref_count += 1;
+                        else
+                            hom_alt_count += 1;
+                    else
+                        het_count += 1;
+
+                    if (a == 0) ref_count += 1;
+                    if (b == 0) ref_count += 1;
+                }
+
+                const uint64_t alt_count = 2 * sample_count - ref_count;
+                const double alt_freq = alt_count / (2.0 * sample_count);
+                const double het_ref_freq = 2 * alt_freq * (1 - alt_freq);
+                const double hom_alt_freq = alt_freq * alt_freq;
+                Index bin_index = 10 * het_ref_freq;
+
+                bin_counts[bin_index] += het_count;
+
+                bin_index = 10 * hom_alt_freq;
+
+                bin_counts[bin_index] += hom_alt_count;
+            }
         }
-
-        const uint64_t alt_count = 2 * sample_count - ref_count;
-        const double alt_freq = alt_count / (2.0 * sample_count);
-        const double het_ref_freq = 2 * alt_freq * (1 - alt_freq);
-        const double hom_alt_freq = alt_freq * alt_freq;
-        Index bin_index = 10 * het_ref_freq;
-
-        bin_counts[bin_index] += het_count;
-
-        bin_index = 10 * hom_alt_freq;
-
-        bin_counts[bin_index] += hom_alt_count;
     }
 
     bin_counts[9] += bin_counts[10];

--- a/software/ts-afdist/ts_afdist.cpp
+++ b/software/ts-afdist/ts_afdist.cpp
@@ -1,7 +1,128 @@
 
 #include <iostream>
+#include "absl/status/status.h"
+#include "tensorstore/array.h"
+#include "tensorstore/open.h"
+#include "tensorstore/spec.h"
+
+/* #include "tensorstore/index.h" */
+#include "tensorstore/index_space/dim_expression.h"
+/* #include "tensorstore/index_space/transformed_array.h" */
+/* #include "tensorstore/util/iterate_over_index_range.h" */
+/* #include "tensorstore/util/status.h" */
+
+using ::tensorstore::Context;
+using ::tensorstore::Index;
+
+/* void count_alleles(tensorstore::Array array) */
+/* { */
+
+/* } */
+
+absl::Status Run(tensorstore::Spec input_spec, std::string output_filename) {
+
+    auto context = Context::Default();
+    TENSORSTORE_ASSIGN_OR_RETURN(
+        auto input,
+        tensorstore::Open(input_spec, context, tensorstore::OpenMode::open,
+                          tensorstore::ReadWriteMode::read)
+            .result());
+
+    auto shape = input.domain().shape();
+    auto num_variants = shape[0];
+    auto num_samples = shape[1];
+    auto ploidy = shape[2];
+    auto chunk_shape = input.chunk_layout().value().read_chunk_shape();
+    auto v_chunk_size = chunk_shape[0];
+    auto s_chunk_size = chunk_shape[1];
+
+    /* if (ploidy != 2) { */
+    /*     std::cerr << "Ploidy must be 2"; */
+    /*     return */
+
+    /* } */
+    std::cout <<  typeid(chunk_shape).name() << std::endl;
+    std::cout << "input shape = " << shape << " chunk shape = " << chunk_shape << std::endl;
+
+    for (auto v_chunk_offset = 0; v_chunk_offset < num_variants;
+            v_chunk_offset += v_chunk_size) {
+
+        for (auto s_chunk_offset = 0; s_chunk_offset < num_samples;
+                s_chunk_offset += s_chunk_size) {
+            std::cout << "Get chunk at " << v_chunk_offset << ", " << s_chunk_offset
+                << std::endl;
+            auto slice = tensorstore::Dims(0, 1).HalfOpenInterval(
+                        {v_chunk_offset, v_chunk_offset + v_chunk_size},
+                        {s_chunk_offset, s_chunk_offset + s_chunk_size});
+            /* auto x = tensorstore::Read<tensorstore::zero_origin>(input | slice).result(); */
+
+            std::vector<int8_t> vec(v_chunk_size * s_chunk_size * ploidy);
+            auto arr = tensorstore::Array(
+                vec.data(), {v_chunk_size, s_chunk_size, ploidy},
+                tensorstore::c_order);
+            /* tensorstore::Read(input , tensorstore::UnownedToShared(arr)).value(); */
+                    /* std::cout << "x = " << slice << std::endl; */
+            /* count_alleles(arr); */
+            // FIXME breaking here. Trying to get tensorstore to read this slice
+            // into the std vector memory allocated above.
+            auto z = tensorstore::Read(input |
+                    tensorstore::Dims(0, 1).HalfOpenInterval(
+                        {v_chunk_offset, v_chunk_offset + v_chunk_size},
+                        {s_chunk_offset, s_chunk_offset + s_chunk_size})
+                    ).result();
+            /* std::cout << "Got " << z << std::endl; */
+
+        }
+    }
+
+
+    /* return absl::OkStatus(); */
+
+    /* TENSORSTORE_ASSIGN_OR_RETURN( */
+    /*     auto data, */
+    /*    tensorstore::Read(input).result()); */
+
+    /* /1* const auto max = data.shape()[data.rank() - 1] - 1; *1/ */
+    /* auto dtype = data.dtype(); */
+    /* std::cout << "dtype = " << dtype << std::endl; */
+
+    /* /1* Read the data into a std::vector of the right size, based on */
+    /*  * https://github.com/google/tensorstore/issues/36#issuecomment-1292757434 */
+    /*  *1/ */
+    /* std::vector<int8_t> vec(num_variants * num_samples * ploidy); */
+    /* auto arr = tensorstore::Array(vec.data(), {num_variants, num_samples, ploidy}, */
+    /*         tensorstore::c_order); */
+    /* tensorstore::Read(input, tensorstore::UnownedToShared(arr)).value(); */
+
+
+    /* auto offset = 0; */
+    /* for (auto v = 0; v < num_variants; v++) { */
+    /*     for (auto s = 0; s < num_samples; s++) { */
+    /*         for (auto z = 0; z < ploidy; z++) { */
+    /*             /1* For some mysterious reason std::cout won't show these values, */
+    /*              * but printf works fine?? *1/ */
+    /*             /1* std::cout << offset << " value = " << p[offset] << std::endl; *1/ */
+    /*             printf("vec[%d] = %d\n", (int) offset, (int) vec[offset]); */
+    /*             offset ++; */
+    /*         } */
+    /*     } */
+    /* } */
+
+    return absl::OkStatus();
+}
 
 int main(int argc, char* argv[]) {
-    std::cout << "hello\n";
+    auto path = argv[1];
+    tensorstore::Spec input_spec =
+        tensorstore::Spec::FromJson(
+            {
+                {"driver", "zarr"}, {"kvstore", {{"driver", "file"}, {"path", path}}},
+                /* {"path", "input"}, */
+            })
+            .value();
+    auto status = Run(input_spec, "tmp.txt");
+    if (!status.ok()) {
+        std::cerr << status << std::endl;
+    }
     return 0;
 }

--- a/software/ts-afdist/ts_afdist.cpp
+++ b/software/ts-afdist/ts_afdist.cpp
@@ -53,6 +53,8 @@ absl::Status Run(tensorstore::Spec input_spec) {
                     const int8_t a = array(variant_index, sample_index, 0);
                     const int8_t b = array(variant_index, sample_index, 1);
 
+                    if (std::min(a, b) < 0) continue;
+
                     if (a == b)
                         if (a == 0)
                             hom_ref_count += 1;


### PR DESCRIPTION
### Overview

We want to compare the performance of an operation on the entire genotype matrix using C++ to read VCF Zarr data to classical approaches using VCF data. To that end, this pull request implements the [bcftools afdist](https://samtools.github.io/bcftools/howtos/plugin.af-dist.html) program in C++ using the [TensorStore library](https://google.github.io/tensorstore/index.html) to read some genotype data stored in VCF format.

This pull request is based on @jeromekelleher's #154.

I believe additional work is needed here (see discussion), but I wanted to open this pull request as a draft for others to examine and/or share ideas.

### Example usage

```
./software/ts-afdist/build/ts_afdist scaling/data/chr21_10_2.zarr/call_genotype
# PROB_DIST, genotype probability distribution, assumes HWE
PROB_DIST       0       0.1     431747
PROB_DIST       0.1     0.2     475194
PROB_DIST       0.2     0.3     585208
PROB_DIST       0.3     0.4     833974
PROB_DIST       0.4     0.5     1855856
PROB_DIST       0.5     0.6     188051
PROB_DIST       0.6     0.7     211121
PROB_DIST       0.7     0.8     169395
PROB_DIST       0.8     0.9     191841
PROB_DIST       0.9     1       745980
```

### Performance

Using the $10^4$-samples genotype data,
```
./software/ts-afdist/build/ts_afdist   77.48s user 2.43s system 98% cpu 1:20.74 total
```

For comparison, bcftools tools on the same data does
```
BCFTOOLS_PLUGINS=software/bcftools-1.18/plugins ./software/bcftools +af-dist   47.42s user 0.28s system 99% cpu 47.840 total
```

The Python-Zarr afdist implementation does
```
scaling/data/chr21_10_4.ts n=10000, m=863998
   num_samples  num_sites  tool  user_time  sys_time  wall_time storage
0        10000     863998  zarr  31.375917   2.02435   30.13042     hdd
```

### Discussion

The performance of the TensorStore implementation is surprisingly slow. I suspect that the slowest step is synchronously reading the chunks from the store. I will see if I can implement asynchronous chunk reading.

The numbers in the TensorStore implementation's output are slightly larger than the numbers in bcftools' output. I also need to determine what the discrepancy is here.

### References

- [bcftools afdist](https://samtools.github.io/bcftools/howtos/plugin.af-dist.html)
- [TensorStore](https://google.github.io/tensorstore/index.html)