### PR TITLE
All of Us example

### DIFF
--- a/all_of_us_example/all_of_us.ipynb
+++ b/all_of_us_example/all_of_us.ipynb
@@ -1,0 +1,141 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3f98f759",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bio2zarr.vcf2zarr import vcz\n",
+    "import numpy as np\n",
+    "import humanfriendly\n",
+    "import os\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "import pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2bcf839b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "VCF_FILE= \"exome.chr20.vcf.bgz\"\n",
+    "ZARR_DIR= \"chr20.vcz\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a204de54",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total compressed VCF: 7.44 GiB\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Total compressed VCF: {humanfriendly.format_size(os.path.getsize(VCF_FILE), binary=True)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "bb7181ce",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.85 s, sys: 2.8 s, total: 4.65 s\n",
+      "Wall time: 1min 18s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "zarrvcf_inspec = vcz.inspect(ZARR_DIR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "93c89d0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zarrdf = pandas.DataFrame(zarrvcf_inspec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9c5f3ca4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zarrdf.to_csv(\"inspect.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "feb1480d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "136847\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "! find {ZARR_DIR} | wc -l"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/all_of_us_example/inspect.csv
+++ b/all_of_us_example/inspect.csv
@@ -1,0 +1,20 @@
+name,dtype,stored,size,ratio,nchunks,chunk_size,avg_chunk_stored,shape,chunk_shape,compressor,filters
+/call_GQ,int8,1.89 GiB,163.47 GiB, 87,17900,9.35 MiB,110.55 KiB,"(715256, 245394)","(1000, 10000)","Blosc(cname='zstd', clevel=7, shuffle=NOSHUFFLE, blocksize=0)",None
+/call_genotype,int8,914.22 MiB,326.93 GiB, 3.7e+02,17900,18.7 MiB,52.3 KiB,"(715256, 245394, 2)","(1000, 10000, 2)","Blosc(cname='zstd', clevel=7, shuffle=BITSHUFFLE, blocksize=0)",None
+/call_RGQ,int16,729.57 MiB,326.93 GiB, 4.6e+02,17900,18.7 MiB,41.74 KiB,"(715256, 245394)","(1000, 10000)","Blosc(cname='zstd', clevel=7, shuffle=NOSHUFFLE, blocksize=0)",None
+/call_genotype_mask,bool,606.02 MiB,326.93 GiB, 5.5e+02,17900,18.7 MiB,34.67 KiB,"(715256, 245394, 2)","(1000, 10000, 2)","Blosc(cname='zstd', clevel=7, shuffle=BITSHUFFLE, blocksize=0)",None
+/call_genotype_phased,bool,17.17 MiB,163.47 GiB, 9.7e+03,17900,9.35 MiB,1006 bytes,"(715256, 245394)","(1000, 10000)","Blosc(cname='zstd', clevel=7, shuffle=BITSHUFFLE, blocksize=0)",None
+/variant_allele,object,4.74 MiB,518.41 MiB, 1.1e+02,716,741.42 KiB,6.78 KiB,"(715256, 95)","(1000, 95)","Blosc(cname='zstd', clevel=7, shuffle=NOSHUFFLE, blocksize=0)",[VLenUTF8()]
+/variant_filter,bool,2.87 MiB,2.73 MiB, 0.95,716,3.9 KiB,4.1 KiB,"(715256, 4)","(1000, 4)","Blosc(cname='zstd', clevel=7, shuffle=BITSHUFFLE, blocksize=0)",None
+/variant_AN,int32,908.75 KiB,2.73 MiB, 3.1,716,3.9 KiB,1.27 KiB,"(715256,)","(1000,)","Blosc(cname='zstd', clevel=7, shuffle=NOSHUFFLE, blocksize=0)",None
+/variant_position,int32,810.77 KiB,2.73 MiB, 3.4,716,3.9 KiB,1.13 KiB,"(715256,)","(1000,)","Blosc(cname='zstd', clevel=7, shuffle=NOSHUFFLE, blocksize=0)",None
+/sample_id,object,357.15 KiB,1.87 MiB, 5.4,25,76.69 KiB,14.29 KiB,"(245394,)","(10000,)","Blosc(cname='zstd', clevel=7, shuffle=SHUFFLE, blocksize=0)",[VLenUTF8()]
+/variant_length,int16,152.4 KiB,1.36 MiB, 9.2,716,1.95 KiB,217 bytes,"(715256,)","(1000,)","Blosc(cname='zstd', clevel=7, shuffle=NOSHUFFLE, blocksize=0)",None
+/variant_id,object,56.18 KiB,5.46 MiB, 99,716,7.8 KiB,80 bytes,"(715256,)","(1000,)","Blosc(cname='zstd', clevel=7, shuffle=NOSHUFFLE, blocksize=0)",[VLenUTF8()]
+/variant_quality,float32,51.92 KiB,2.73 MiB, 54,716,3.9 KiB,74 bytes,"(715256,)","(1000,)","Blosc(cname='zstd', clevel=7, shuffle=NOSHUFFLE, blocksize=0)",None
+/variant_id_mask,bool,51.89 KiB,698.49 KiB, 13,716,998.9608938547486 bytes,74 bytes,"(715256,)","(1000,)","Blosc(cname='zstd', clevel=7, shuffle=BITSHUFFLE, blocksize=0)",None
+/variant_contig,int16,50.6 KiB,1.36 MiB, 28,716,1.95 KiB,72 bytes,"(715256,)","(1000,)","Blosc(cname='zstd', clevel=7, shuffle=NOSHUFFLE, blocksize=0)",None
+/region_index,int32,13.93 KiB,16.78 KiB, 1.2,1,16.78 KiB,13.93 KiB,"(716, 6)","(716, 6)","Blosc(cname='zstd', clevel=9, shuffle=NOSHUFFLE, blocksize=0)",None
+/contig_length,int64,9.24 KiB,26.3 KiB, 2.8,1,26.3 KiB,9.24 KiB,"(3366,)","(3366,)","Blosc(cname='zstd', clevel=7, shuffle=SHUFFLE, blocksize=0)",None
+/contig_id,object,8.33 KiB,26.3 KiB, 3.2,1,26.3 KiB,8.33 KiB,"(3366,)","(3366,)","Blosc(cname='zstd', clevel=7, shuffle=SHUFFLE, blocksize=0)",[VLenUTF8()]
+/filter_id,object,4.48 KiB,32 bytes, 0.007,1,32.0 bytes,4.48 KiB,"(4,)","(4,)","Blosc(cname='zstd', clevel=7, shuffle=SHUFFLE, blocksize=0)",[VLenUTF8()]


### PR DESCRIPTION
PR for #191.

I added the notebook and inspect output for the exome of chromosome 20 from All of Us data (about 250k individuals).
Only the inspect on the `vcz` file is added in this PR, because for some reasons `inspect` did not work on the `icf`.

Here is a short draft to describe the data:

The All of Us dataset comprises 245,388 clinical-grade whole genome sequences, identifying over 1 billion variants, including 3.9 million novel variants with coding consequences. Participants are from the United States, with an emphasis on historically underrepresented genetic ancestry groups. The genomic data is of high quality, with an average coverage depth of 30x, and is linked to extensive health-related information, providing a valuable resource for biomedical research. For this study, we applied the bio2zarr compression method to the exome data for chromosome 20 from All of Us. This dataset, stored as a compressed VCF file of 7.44 GiB, includes 681,000 variants, of which 746 are classified as pathogenic or likely pathogenic.

Citation: The All of Us Research Program Genomics Investigators. Genomic data in the All of Us Research Program. Nature 627, 340–346 (2024). [https://doi.org/10.1038/s41586-023-06957-x](https://doi.org/10.1038/s41586-023-06957-x)
Browser: [https://databrowser.researchallofus.org/](https://databrowser.researchallofus.org/)


@jeromekelleher 
