### PR TITLE
Add comparison to bcf in AoU notebook

### DIFF
--- a/all_of_us_example/all_of_us.ipynb
+++ b/all_of_us_example/all_of_us.ipynb
@@ -26,12 +26,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "2bcf839b",
    "metadata": {},
    "outputs": [],
    "source": [
     "VCF_FILE= \"exome.chr20.vcf.bgz\"\n",
+    "BCF_FILE= \"exome.chr20.bcf\"\n",
     "ZARR_DIR2= \"exome.chr20_all3.vcz\"\n",
     "ICF_DIR= \"chr20.icf\""
    ]
@@ -229,11 +230,37 @@
    "source": [
     "! du -sh {ICF_DIR}"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "580b20e6",
+   "metadata": {},
+   "source": [
+    "## Comparison with bcf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d6f1c97a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8.8G\texome.chr20.bcf\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "! du -sh {BCF_FILE}"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
I added a comparison in the notebook between the size of VCZ (8.5G) and BCF (8.8G).

@jeromekelleher 